### PR TITLE
 TypeError fixed in the rare case that the instance got shut down

### DIFF
--- a/src/Facades/Mastodon.php
+++ b/src/Facades/Mastodon.php
@@ -17,6 +17,7 @@ use Revolution\Mastodon\Contracts\Factory;
  * @method static array createStatus(string $status, array $options = [])
  * @method static array status(int $status_id)
  * @method static void streaming(string $url, callable $callback)
+ * @method static ?array call(string $method, string $api, array $options = [])
  */
 class Mastodon extends Facade
 {

--- a/src/MastodonClient.php
+++ b/src/MastodonClient.php
@@ -36,7 +36,7 @@ class MastodonClient implements Factory
         $this->client = $client;
     }
 
-    public function call(string $method, string $api, array $options = []): array
+    public function call(string $method, string $api, array $options = []): ?array
     {
         $url = $this->apiEndpoint().$api;
 
@@ -46,7 +46,9 @@ class MastodonClient implements Factory
 
         $this->response = $this->client->request($method, $url, $options);
 
-        return json_decode($this->response->getBody(), true);
+        $response = json_decode($this->response->getBody(), true);
+
+        return is_array($response) ? $response : null;
     }
 
     public function get(string $api, array $query = []): array


### PR DESCRIPTION
We've experienced some rare cases where users provided their own mastodon instance but shut them down with one singular landing page and a status code of 200. `json_decode` accidentally returned null this way.

This should fix this error. :)
